### PR TITLE
Improve GTF parsing

### DIFF
--- a/src/pyroe/make_txome.py
+++ b/src/pyroe/make_txome.py
@@ -274,7 +274,7 @@ def check_gr(gr, output_dir):
     # 2. using exons' bounds as the bound of transcripts/genes to extract unspliced sequences
     # 3. write those bounds to the clean gtf file
 
-    if transcript_gr.empty or gene_gr.empty: 
+    if transcript_gr.empty or gene_gr.empty:
         if transcript_gr.empty:
             warnings.warn(
                 "".join(
@@ -284,7 +284,7 @@ def check_gr(gr, output_dir):
                     ]
                 )
             )
-            
+
             transcript_gr = transcript_bound_from_exons
             clean_transcript_gr = transcript_bound_from_exons
             gr = pr.concat([gr, transcript_bound_from_exons])
@@ -314,7 +314,9 @@ def check_gr(gr, output_dir):
         if transcript_gr.length > transcript_bound_from_exons.length:
             # pyranges will ignore it anyway. Here I filter them out manually.
             transcript_gr = transcript_gr[
-                transcript_gr.transcript_id.isin(transcript_bound_from_exons.transcript_id)
+                transcript_gr.transcript_id.isin(
+                    transcript_bound_from_exons.transcript_id
+                )
             ]
 
             # complain
@@ -392,7 +394,9 @@ def check_gr(gr, output_dir):
             set(gene_bound_from_exons.gene_id)
         )
 
-        if not gene_gr[gene_gr.gene_id.isin(intersecting_gs)][["Start", "End"]].df.equals(
+        if not gene_gr[gene_gr.gene_id.isin(intersecting_gs)][
+            ["Start", "End"]
+        ].df.equals(
             gene_bound_from_exons[gene_bound_from_exons.gene_id.isin(intersecting_gs)][
                 ["Start", "End"]
             ].df

--- a/src/pyroe/make_txome.py
+++ b/src/pyroe/make_txome.py
@@ -1,5 +1,4 @@
 import os
-import warnings
 import subprocess
 import shutil
 import pyranges as pr
@@ -12,6 +11,7 @@ from Bio.SeqRecord import SeqRecord
 from Bio.SeqIO.FastaIO import SimpleFastaParser
 from packaging.version import parse as parse_version
 import logging
+
 
 def append_extra(extra_infile, out_fa, out_t2g3col, id2name_path, col_status):
     """
@@ -136,7 +136,9 @@ def check_gr(gr, output_dir):
                 " The input GTF file doesn't contain gene_id and gene_name metadata field; Cannot proceed."
             )
         else:
-            logging.warning(" The gene_id field does not exist; Imputing using gene_name.")
+            logging.warning(
+                " The gene_id field does not exist; Imputing using gene_name."
+            )
             gene_id = pd.Series(data=gr.gene_name, name="gene_id")
             gr = gr.insert(gene_id)
 
@@ -548,28 +550,33 @@ def make_splici_txome(
             if bt_path == "bedtools":
                 # in this case, there's nowhere else to check
                 # so give up on bedtools
-                logging.warning("".join([
-                    " Bedtools in the environemnt PATH is either",
-                    " older than v.2.30.0 or doesn't exist.",
-                    " Biopython will be used to extract sequences.",
-                    
-                ])
+                logging.warning(
+                    "".join(
+                        [
+                            " Bedtools in the environemnt PATH is either",
+                            " older than v.2.30.0 or doesn't exist.",
+                            " Biopython will be used to extract sequences.",
+                        ]
+                    )
                 )
                 no_bt = True
             else:
                 logging.warning(
                     " Bedtools specified by bt_path is either",
                     " older than v.2.30.0 or doesn't exist.",
-                    " Trying to find bedtools in the environmental PATH."
+                    " Trying to find bedtools in the environmental PATH.",
                 )
                 # if it's not ok at the standard system path
                 # fallback to biopython
                 if not check_bedtools_version("bedtools"):
-                    logging.warning("".join([
-                        " Bedtools in the environemnt PATH is either",
-                        " older than v.2.30.0 or doesn't exist.",
-                        " Biopython will be used to extract sequences.",
-                    ])
+                    logging.warning(
+                        "".join(
+                            [
+                                " Bedtools in the environemnt PATH is either",
+                                " older than v.2.30.0 or doesn't exist.",
+                                " Biopython will be used to extract sequences.",
+                            ]
+                        )
                     )
                     no_bt = True
                 # found it at the system path
@@ -593,12 +600,15 @@ def make_splici_txome(
         gr = pr.read_gtf(gtf_path)
     except ValueError as err:
         # in this case couldn't even read the GTF file
-        logging.error("".join([
-            " PyRanges failed to parse the input GTF file.",
-            " Please check the PyRanges documentation for the expected GTF format constraints at",
-            " https://pyranges.readthedocs.io/en/latest/autoapi/pyranges/readers/index.html?highlight=read_gtf#pyranges.readers.read_gtf .",
-            f" The error message was: {str(err)}"
-        ])
+        logging.error(
+            "".join(
+                [
+                    " PyRanges failed to parse the input GTF file.",
+                    " Please check the PyRanges documentation for the expected GTF format constraints at",
+                    " https://pyranges.readthedocs.io/en/latest/autoapi/pyranges/readers/index.html?highlight=read_gtf#pyranges.readers.read_gtf .",
+                    f" The error message was: {str(err)}",
+                ]
+            )
         )
 
     # check the validity of gr
@@ -646,18 +656,22 @@ def make_splici_txome(
             title.split()[0]: len(sequence)
             for title, sequence in SimpleFastaParser(fasta_file)
         }
-        
-        
+
     # in case the genome and gene annotaitons do not match
     # try it and raise value error if this fails
-    try: 
+    try:
         introns = pr.gf.genome_bounds(introns, chromsize, clip=True)
     except Exception as err:
-        logging.error("".join([" Failed to refine intron bounds using genome bounds.",
-                               " Please check if the input genome FASTA file and GTF file match each other.", 
-                               f" The error message was: {str(err)}",
-                              ]),
-                      exc_info=True)    # deduplicate introns
+        logging.error(
+            "".join(
+                [
+                    " Failed to refine intron bounds using genome bounds.",
+                    " Please check if the input genome FASTA file and GTF file match each other.",
+                    f" The error message was: {str(err)}",
+                ]
+            ),
+            exc_info=True,
+        )  # deduplicate introns
     if dedup_seqs:
         introns.drop_duplicate_positions()
     # add splice status for introns
@@ -751,7 +765,9 @@ def make_splici_txome(
             shutil.rmtree(temp_dir, ignore_errors=True)
         except Exception as err:
             no_bt = True
-            logging.warning(f" Bedtools failed; Using biopython instead. The error message was: \n{err}")
+            logging.warning(
+                f" Bedtools failed; Using biopython instead. The error message was: \n{err}"
+            )
             shutil.rmtree(temp_dir, ignore_errors=True)
 
     if no_bt:
@@ -929,28 +945,37 @@ def make_spliceu_txome(
             if bt_path == "bedtools":
                 # in this case, there's nowhere else to check
                 # so give up on bedtools
-                logging.warning("".join([
-                    " Bedtools in the environemnt PATH is either",
-                    " older than v.2.30.0 or doesn't exist.",
-                    " Biopython will be used.",
-                ])
+                logging.warning(
+                    "".join(
+                        [
+                            " Bedtools in the environemnt PATH is either",
+                            " older than v.2.30.0 or doesn't exist.",
+                            " Biopython will be used.",
+                        ]
+                    )
                 )
                 no_bt = True
             else:
-                logging.warning("".join([
-                    "Bedtools specified by bt_path is either",
-                    "older than v.2.30.0 or doesn't exist.",
-                    "Trying to find bedtools in the environmental PATH.",
-                ])
+                logging.warning(
+                    "".join(
+                        [
+                            "Bedtools specified by bt_path is either",
+                            "older than v.2.30.0 or doesn't exist.",
+                            "Trying to find bedtools in the environmental PATH.",
+                        ]
+                    )
                 )
                 # if it's not ok at the standard system path
                 # fallback to biopython
                 if not check_bedtools_version("bedtools"):
-                    logging.warning("".join([
-                        " Bedtools in the environemnt PATH is either",
-                        " older than v.2.30.0 or doesn't exist.",
-                        " Biopython will be used.",
-                        ])
+                    logging.warning(
+                        "".join(
+                            [
+                                " Bedtools in the environemnt PATH is either",
+                                " older than v.2.30.0 or doesn't exist.",
+                                " Biopython will be used.",
+                            ]
+                        )
                     )
                     no_bt = True
                 # found it at the system path
@@ -975,13 +1000,18 @@ def make_spliceu_txome(
         gr = pr.read_gtf(gtf_path)
     except ValueError as err:
         # in this case couldn't even run subprocess
-        logging.error(''.join([" PyRanges failed to parse the input GTF file.",
-                               " Please check the PyRanges documentation for ",
-                               " the expected GTF format constraints at",
-                               " https://pyranges.readthedocs.io/en/latest/autoapi/pyranges/readers/index.html?highlight=read_gtf#pyranges.readers.read_gtf .",
-                               f" The error message was: {str(err)}"]),
-                      exc_info=True
-            )
+        logging.error(
+            "".join(
+                [
+                    " PyRanges failed to parse the input GTF file.",
+                    " Please check the PyRanges documentation for ",
+                    " the expected GTF format constraints at",
+                    " https://pyranges.readthedocs.io/en/latest/autoapi/pyranges/readers/index.html?highlight=read_gtf#pyranges.readers.read_gtf .",
+                    f" The error message was: {str(err)}",
+                ]
+            ),
+            exc_info=True,
+        )
 
     # check the validity of gr
     gr = check_gr(gr, output_dir)
@@ -1089,7 +1119,9 @@ def make_spliceu_txome(
             shutil.rmtree(temp_dir, ignore_errors=True)
         except Exception as err:
             no_bt = True
-            logging.warning(f" Bedtools failed; Using biopython instead. The error message was: {err}")
+            logging.warning(
+                f" Bedtools failed; Using biopython instead. The error message was: {err}"
+            )
             shutil.rmtree(temp_dir, ignore_errors=True)
 
     if no_bt:


### PR DESCRIPTION
Pyroe build expanded transcriptome references, the spliced + intronic (*splici*) transcriptome reference and the spliced + unspliced (*spliceu*) transcriptome reference based on a genome build FASTA file and a gene annotation GTF file.

The input GTF file will be processed before extracting unspliced sequences. If pyroe finds invalid records, a `clean_gtf.gtf` file will be generated in the specified output directory.  **Note** : The features extracted in the spliced + unspliced transcriptome will not necessarily be those present in the `clean_gtf.gtf` file — as this command will prefer the input in the user-provided file wherever possible.  More specifically:
1. Each non-gene record has to have a valid transcript_id. If this is not satisfied, it returns an error. Only the records with a valid transcript_id will be written to the clean_gtf.gtf.
2. For gene_id and gene_name metadata field, 
  - If these two fields are entirely missing in the GTF file, An error will be returned. At the same time, in the clean_gtf.gtf, the two fields will be imputed using the transcript_id fields.
  - If one of these two fields is completely missing, a warning will be generated, and the missing field will be imputed using the other one.
  - if some records have missing gene_id and/or gene_name, a warning will be printed, and the missing values will be imputed by the following rules: For records miss gene_id or gene_name, impute the missing one using the other one; If both are missing, impute them using transcript_id, which cannot be missing. 
3. If there is no "transcript" or "gene" feature record, a warning will be printed. Moreover, those missing records will be imputed using the "exon" feature records: The Start and End site of the gene/transcript will be imputed as the bounds of their corresponding exons.
4. If the boundaries defined in the transcripts'/genes' feature records do not match those implied by their exons' feature records, report a warning but still use transcripts'/genes' feature records to extract unspliced sequences. To be specific, if some but not all transcripts/genes have their corresponding transcripts'/genes' feature records, or the Start and/or End site defined in the transcript/gene feature records do not match the corresponding exons' bounds, then the existing transcripts'/genes' feature records will be used to extract unspliced transcripts. At the same time, in the clean_gtf.gtf, all genes/transcripts that appeared in the exon feature records will have their corresponding transcripts'/genes' feature records, in which the boundaries match the corresponding exons' bounds.  
