### PR TITLE
fix: refine bed file formats

### DIFF
--- a/bin/pyroe
+++ b/bin/pyroe
@@ -100,11 +100,6 @@ if __name__ == "__main__":
         action="store_true",
         help="A flag indicates whether flank lengths will be considered when merging introns.",
     )
-    parser_makeSplici.add_argument(
-        "--write-clean-gtf",
-        action="store_true",
-        help="A flag indicates whether a clean gtf will be written if encountered invalid records.",
-    )
 
     # make-spliceu
     parser_makeSpliceu = subparsers.add_parser(
@@ -158,11 +153,6 @@ if __name__ == "__main__":
         "--dedup-seqs",
         action="store_true",
         help="A flag indicates whether identical sequences will be deduplicated.",
-    )
-    parser_makeSpliceu.add_argument(
-        "--write-clean-gtf",
-        action="store_true",
-        help="A flag indicates whether a clean gtf will be written if encountered invalid records.",
     )
 
     # parse available datasets
@@ -274,7 +264,6 @@ if __name__ == "__main__":
             no_bt=args.no_bt,
             bt_path=args.bt_path,
             no_flanking_merge=args.no_flanking_merge,
-            write_clean_gtf=args.write_clean_gtf,
         )
     elif args.command == "make-spliceu":
         make_spliceu_txome(
@@ -287,7 +276,6 @@ if __name__ == "__main__":
             dedup_seqs=args.dedup_seqs,
             no_bt=args.no_bt,
             bt_path=args.bt_path,
-            write_clean_gtf=args.write_clean_gtf,
         )
     elif args.command == "fetch-quant":
         fetch_processed_quant(

--- a/src/pyroe/make_txome.py
+++ b/src/pyroe/make_txome.py
@@ -12,6 +12,8 @@ from Bio.SeqIO.FastaIO import SimpleFastaParser
 from packaging.version import parse as parse_version
 import logging
 
+bed_required_fields = ['Chromosome', 'Start', 'End', 'Strand', 'Name', 'Gene','splice_status']
+
 
 def append_extra(extra_infile, out_fa, out_t2g3col, id2name_path, col_status):
     """
@@ -608,7 +610,8 @@ def make_splici_txome(
                     " https://pyranges.readthedocs.io/en/latest/autoapi/pyranges/readers/index.html?highlight=read_gtf#pyranges.readers.read_gtf .",
                     f" The error message was: {str(err)}",
                 ]
-            )
+            ),
+            exc_info=True,
         )
 
     # check the validity of gr
@@ -677,20 +680,21 @@ def make_splici_txome(
     # add splice status for introns
     introns.splice_status = "U"
 
+    introns = introns[bed_required_fields]
+
     # get exons
     exons = gr[gr.Feature == "exon"]
 
     exons.Name = exons.transcript_id
     exons.Gene = exons.gene_id
-    exons = exons.drop(exons.columns[~exons.columns.isin(introns.columns)].tolist())
     exons = exons.sort(["Name", "Start", "End"])
     # add splice status for exons
     exons.splice_status = "S"
+    # keep only required fields 
+    exons = exons[bed_required_fields]
 
     # concat spliced transcripts and introns as splici
     splici = pr.concat([exons, introns])
-
-    # splici = splici.sort(["Name", "Start", "End", "Gene"])
 
     # write to files
     # t2g_3col.tsv
@@ -762,13 +766,13 @@ def make_splici_txome(
                 if tid2strand[prev_rec.id] == "-":
                     prev_rec = prev_rec.reverse_complement(id=True, description=True)
                 SeqIO.write(prev_rec, out_handle, "fasta")
-            shutil.rmtree(temp_dir, ignore_errors=True)
+            # shutil.rmtree(temp_dir, ignore_errors=True)
         except Exception as err:
             no_bt = True
             logging.warning(
                 f" Bedtools failed; Using biopython instead. The error message was: \n{err}"
             )
-            shutil.rmtree(temp_dir, ignore_errors=True)
+            # shutil.rmtree(temp_dir, ignore_errors=True)
 
     if no_bt:
         with open(out_fa, "w") as out_handle:
@@ -867,7 +871,6 @@ def make_spliceu_txome(
     dedup_seqs=False,
     no_bt=False,
     bt_path="bedtools",
-    write_clean_gtf=False,
 ):
     """
     Construct the spliceu (spliced + unspliced) transcriptome for alevin-fry.
@@ -1023,20 +1026,25 @@ def make_spliceu_txome(
 
     # get unspliced
     unspliced = gr[gr.Feature == "gene"]
+    # unspliced = gr.boundaries("gene_id")
     unspliced.Name = unspliced.gene_id + "-I"
     unspliced.Gene = unspliced.gene_id
-
     # add splice status for unspliced
     unspliced.splice_status = "U"
+    # keep only required fields
+    unspliced = unspliced[bed_required_fields]
 
     # get exons
     exons = gr[gr.Feature == "exon"]
 
     exons.Name = exons.transcript_id
     exons.Gene = exons.gene_id
+
     exons = exons.sort(["Name", "Start", "End"])
     # add splice status for exons
     exons.splice_status = "S"
+    # keep only required fields 
+    exons = exons[bed_required_fields]
 
     # concat spliced transcripts and unspliced as spliceu
     spliceu = pr.concat([exons, unspliced])
@@ -1052,7 +1060,6 @@ def make_spliceu_txome(
     # g2g.csv
     t2g_3col[["Gene", "Gene"]].to_csv(out_g2g, sep="\t", header=False, index=False)
 
-    # print(spliceu.head())
     tid2strand = dict(zip(spliceu.Name, spliceu.Strand))
 
     # spliceu fasta
@@ -1122,7 +1129,7 @@ def make_spliceu_txome(
             logging.warning(
                 f" Bedtools failed; Using biopython instead. The error message was: {err}"
             )
-            shutil.rmtree(temp_dir, ignore_errors=True)
+            # shutil.rmtree(temp_dir, ignore_errors=True)
 
     if no_bt:
         with open(out_fa, "w") as out_handle:

--- a/src/pyroe/make_txome.py
+++ b/src/pyroe/make_txome.py
@@ -1090,7 +1090,7 @@ def make_spliceu_txome(
 
             # check return code
             if bt_r.returncode != 0:
-                logging.exception("Bedtools failed.")
+                logging.exception("Bedtools failed.", exc_info=True)
 
             # parse temp fasta file to concat exons of each transcript
             ei_parser = SeqIO.parse(temp_fa, "fasta")

--- a/src/pyroe/make_txome.py
+++ b/src/pyroe/make_txome.py
@@ -1,5 +1,4 @@
 import os
-import warnings
 import subprocess
 import shutil
 import pyranges as pr
@@ -12,6 +11,7 @@ from Bio.SeqRecord import SeqRecord
 from Bio.SeqIO.FastaIO import SimpleFastaParser
 from packaging.version import parse as parse_version
 import logging
+
 
 def append_extra(extra_infile, out_fa, out_t2g3col, id2name_path, col_status):
     """
@@ -136,7 +136,9 @@ def check_gr(gr, output_dir):
                 " The input GTF file doesn't contain gene_id and gene_name metadata field; Cannot proceed."
             )
         else:
-            logging.warning(" The gene_id field does not exist; Imputing using gene_name.")
+            logging.warning(
+                " The gene_id field does not exist; Imputing using gene_name."
+            )
             gene_id = pd.Series(data=gr.gene_name, name="gene_id")
             gr = gr.insert(gene_id)
 
@@ -548,28 +550,33 @@ def make_splici_txome(
             if bt_path == "bedtools":
                 # in this case, there's nowhere else to check
                 # so give up on bedtools
-                logging.warning("".join([
-                    " Bedtools in the environemnt PATH is either",
-                    " older than v.2.30.0 or doesn't exist.",
-                    " Biopython will be used to extract sequences.",
-                    
-                ])
+                logging.warning(
+                    "".join(
+                        [
+                            " Bedtools in the environemnt PATH is either",
+                            " older than v.2.30.0 or doesn't exist.",
+                            " Biopython will be used to extract sequences.",
+                        ]
+                    )
                 )
                 no_bt = True
             else:
                 logging.warning(
                     " Bedtools specified by bt_path is either",
                     " older than v.2.30.0 or doesn't exist.",
-                    " Trying to find bedtools in the environmental PATH."
+                    " Trying to find bedtools in the environmental PATH.",
                 )
                 # if it's not ok at the standard system path
                 # fallback to biopython
                 if not check_bedtools_version("bedtools"):
-                    logging.warning("".join([
-                        " Bedtools in the environemnt PATH is either",
-                        " older than v.2.30.0 or doesn't exist.",
-                        " Biopython will be used to extract sequences.",
-                    ])
+                    logging.warning(
+                        "".join(
+                            [
+                                " Bedtools in the environemnt PATH is either",
+                                " older than v.2.30.0 or doesn't exist.",
+                                " Biopython will be used to extract sequences.",
+                            ]
+                        )
                     )
                     no_bt = True
                 # found it at the system path
@@ -593,12 +600,15 @@ def make_splici_txome(
         gr = pr.read_gtf(gtf_path)
     except ValueError as err:
         # in this case couldn't even read the GTF file
-        logging.error("".join([
-            " PyRanges failed to parse the input GTF file.",
-            " Please check the PyRanges documentation for the expected GTF format constraints at",
-            " https://pyranges.readthedocs.io/en/latest/autoapi/pyranges/readers/index.html?highlight=read_gtf#pyranges.readers.read_gtf .",
-            f" The error message was: {str(err)}"
-        ])
+        logging.error(
+            "".join(
+                [
+                    " PyRanges failed to parse the input GTF file.",
+                    " Please check the PyRanges documentation for the expected GTF format constraints at",
+                    " https://pyranges.readthedocs.io/en/latest/autoapi/pyranges/readers/index.html?highlight=read_gtf#pyranges.readers.read_gtf .",
+                    f" The error message was: {str(err)}",
+                ]
+            )
         )
 
     # check the validity of gr
@@ -646,18 +656,22 @@ def make_splici_txome(
             title.split()[0]: len(sequence)
             for title, sequence in SimpleFastaParser(fasta_file)
         }
-        
-        
+
     # in case the genome and gene annotaitons do not match
     # try it and raise value error if this fails
-    try: 
+    try:
         introns = pr.gf.genome_bounds(introns, chromsize, clip=True)
     except Exception as err:
-        logging.error("".join([" Failed to refine intron bounds using genome bounds.",
-                               " Please check if the input genome FASTA file and GTF file match each other.", 
-                               f" The error message was: {str(err)}",
-                              ]),
-                      exc_info=True)    # deduplicate introns
+        logging.error(
+            "".join(
+                [
+                    " Failed to refine intron bounds using genome bounds.",
+                    " Please check if the input genome FASTA file and GTF file match each other.",
+                    f" The error message was: {str(err)}",
+                ]
+            ),
+            exc_info=True,
+        )  # deduplicate introns
     if dedup_seqs:
         introns.drop_duplicate_positions()
     # add splice status for introns
@@ -751,7 +765,9 @@ def make_splici_txome(
             shutil.rmtree(temp_dir, ignore_errors=True)
         except Exception as err:
             no_bt = True
-            logging.warning(f" Bedtools failed; Using biopython instead. The error message was: \n{err}")
+            logging.warning(
+                f" Bedtools failed; Using biopython instead. The error message was: \n{err}"
+            )
             shutil.rmtree(temp_dir, ignore_errors=True)
 
     if no_bt:
@@ -929,28 +945,37 @@ def make_spliceu_txome(
             if bt_path == "bedtools":
                 # in this case, there's nowhere else to check
                 # so give up on bedtools
-                logging.warning("".join([
-                    " Bedtools in the environemnt PATH is either",
-                    " older than v.2.30.0 or doesn't exist.",
-                    " Biopython will be used.",
-                ])
+                logging.warning(
+                    "".join(
+                        [
+                            " Bedtools in the environemnt PATH is either",
+                            " older than v.2.30.0 or doesn't exist.",
+                            " Biopython will be used.",
+                        ]
+                    )
                 )
                 no_bt = True
             else:
-                logging.warning("".join([
-                    "Bedtools specified by bt_path is either",
-                    "older than v.2.30.0 or doesn't exist.",
-                    "Trying to find bedtools in the environmental PATH.",
-                ])
+                logging.warning(
+                    "".join(
+                        [
+                            "Bedtools specified by bt_path is either",
+                            "older than v.2.30.0 or doesn't exist.",
+                            "Trying to find bedtools in the environmental PATH.",
+                        ]
+                    )
                 )
                 # if it's not ok at the standard system path
                 # fallback to biopython
                 if not check_bedtools_version("bedtools"):
-                    logging.warning("".join([
-                        " Bedtools in the environemnt PATH is either",
-                        " older than v.2.30.0 or doesn't exist.",
-                        " Biopython will be used.",
-                        ])
+                    logging.warning(
+                        "".join(
+                            [
+                                " Bedtools in the environemnt PATH is either",
+                                " older than v.2.30.0 or doesn't exist.",
+                                " Biopython will be used.",
+                            ]
+                        )
                     )
                     no_bt = True
                 # found it at the system path
@@ -975,13 +1000,18 @@ def make_spliceu_txome(
         gr = pr.read_gtf(gtf_path)
     except ValueError as err:
         # in this case couldn't even run subprocess
-        logging.error(''.join([" PyRanges failed to parse the input GTF file.",
-                               " Please check the PyRanges documentation for ",
-                               " the expected GTF format constraints at",
-                               " https://pyranges.readthedocs.io/en/latest/autoapi/pyranges/readers/index.html?highlight=read_gtf#pyranges.readers.read_gtf .",
-                               f" The error message was: {str(err)}"]),
-                      exc_info=True
-            )
+        logging.error(
+            "".join(
+                [
+                    " PyRanges failed to parse the input GTF file.",
+                    " Please check the PyRanges documentation for ",
+                    " the expected GTF format constraints at",
+                    " https://pyranges.readthedocs.io/en/latest/autoapi/pyranges/readers/index.html?highlight=read_gtf#pyranges.readers.read_gtf .",
+                    f" The error message was: {str(err)}",
+                ]
+            ),
+            exc_info=True,
+        )
 
     # check the validity of gr
     gr = check_gr(gr, output_dir)
@@ -1089,7 +1119,9 @@ def make_spliceu_txome(
             shutil.rmtree(temp_dir, ignore_errors=True)
         except Exception as err:
             no_bt = True
-            logging.warning(f" Bedtools failed; Using biopython instead. The error message was: {err}")
+            logging.warning(
+                f" Bedtools failed; Using biopython instead. The error message was: {err}"
+            )
             shutil.rmtree(temp_dir, ignore_errors=True)
 
     if no_bt:

--- a/src/pyroe/make_txome.py
+++ b/src/pyroe/make_txome.py
@@ -12,7 +12,15 @@ from Bio.SeqIO.FastaIO import SimpleFastaParser
 from packaging.version import parse as parse_version
 import logging
 
-bed_required_fields = ['Chromosome', 'Start', 'End', 'Strand', 'Name', 'Gene','splice_status']
+bed_required_fields = [
+    "Chromosome",
+    "Start",
+    "End",
+    "Strand",
+    "Name",
+    "Gene",
+    "splice_status",
+]
 
 
 def append_extra(extra_infile, out_fa, out_t2g3col, id2name_path, col_status):
@@ -690,7 +698,7 @@ def make_splici_txome(
     exons = exons.sort(["Name", "Start", "End"])
     # add splice status for exons
     exons.splice_status = "S"
-    # keep only required fields 
+    # keep only required fields
     exons = exons[bed_required_fields]
 
     # concat spliced transcripts and introns as splici
@@ -1043,7 +1051,7 @@ def make_spliceu_txome(
     exons = exons.sort(["Name", "Start", "End"])
     # add splice status for exons
     exons.splice_status = "S"
-    # keep only required fields 
+    # keep only required fields
     exons = exons[bed_required_fields]
 
     # concat spliced transcripts and unspliced as spliceu


### PR DESCRIPTION
Explicitly defined the 8 fields required by bedtools and discarded all other fields. 